### PR TITLE
Limit SSM Distributor associations to Supported Regions

### DIFF
--- a/guide/content/pre-deployment-steps.md
+++ b/guide/content/pre-deployment-steps.md
@@ -7,7 +7,7 @@ description: Predeployment steps.
 Before deploying this ABI solution, complete the following steps:
 
 1. Subscribe to the [CrowdStrike Falcon Cloud Security](https://aws.amazon.com/marketplace/pp/prodview-l6ti2ml2i2g6y?ref_=esp&feature_=FeaturedProducts) AWS Marketplace listing.
-2. Create Crowdstrike API Client in Falcon UI with the fopllowing scope: CSPM registration: Read and Write, CSPM sensor management: Read and Write, Installation Tokens: Read, Sensor Download: Read
+2. Create Crowdstrike API Client in Falcon UI with the following scope: CSPM registration: Read and Write, CSPM sensor management: Read and Write, Installation Tokens: Read, Sensor Download: Read
 3. Become familiar with the [additional resources](/additional-resources/index.html) later in this guide.
 
 **Next:** Choose [Deployment steps](/deployment-steps/index.html).

--- a/lambda_functions/source/register-organization/lambda.py
+++ b/lambda_functions/source/register-organization/lambda.py
@@ -150,7 +150,7 @@ def lambda_handler(event, context):
     logger.info('Context {}'.format(context))
     aws_account_id = context.invoked_function_arn.split(":")[4]
     regions = get_active_regions(AWS_REGION)
-    ssm_regions = get_ssm_regions
+    ssm_regions = get_ssm_regions()
     OrgId = get_management_id()
     try:
         secret_str = get_secret(SECRET_STORE_NAME, SECRET_STORE_REGION)

--- a/lambda_functions/source/register-organization/lambda.py
+++ b/lambda_functions/source/register-organization/lambda.py
@@ -87,6 +87,38 @@ def get_active_regions(AWS_REGION):
         return my_regions
     except Exception as e:
         return e
+
+def get_ssm_regions():
+    try:
+        supported_regions = [
+            "af-south-1",
+            "ap-east-1",
+            "ap-northeast-1",
+            "ap-northeast-2",
+            "ap-south-1",
+            "ap-southeast-1",
+            "ap-southeast-2",
+            "ca-central-1",
+            "eu-central-1",
+            "eu-north-1",
+            "eu-south-1",
+            "eu-west-1",
+            "eu-west-2",
+            "eu-west-3",
+            "me-south-1",
+            "sa-east-1",
+            "us-east-1",
+            "us-east-2",
+            "us-west-1",
+            "us-west-2"
+        ]
+        ssm_regions = []
+        for supported_region in supported_regions:
+            if supported_region not in EXCLUDE_REGIONS:
+                ssm_regions += [supported_region]
+        return ssm_regions
+    except Exception as e:
+        return e
     
 def cfnresponse_send(event, context, responseStatus, responseData, physicalResourceId=None, noEcho=False):
     responseUrl = event['ResponseURL']
@@ -118,6 +150,7 @@ def lambda_handler(event, context):
     logger.info('Context {}'.format(context))
     aws_account_id = context.invoked_function_arn.split(":")[4]
     regions = get_active_regions(AWS_REGION)
+    ssm_regions = get_ssm_regions
     OrgId = get_management_id()
     try:
         secret_str = get_secret(SECRET_STORE_NAME, SECRET_STORE_REGION)
@@ -159,6 +192,7 @@ def lambda_handler(event, context):
                         "eventbus_name": response['body']['resources'][0]['eventbus_name']
                     }
                     response_d['my_regions'] = regions
+                    response_d['ssm_regions'] = ssm_regions
                     cfnresponse_send(event, context, SUCCESS, response_d, "CustomResourcePhysicalID")
                 else:
                     response_d = response['body']

--- a/lambda_functions/source/register-organization/lambda.py
+++ b/lambda_functions/source/register-organization/lambda.py
@@ -74,49 +74,43 @@ def get_active_regions(AWS_REGION):
         service_name='ec2',
         region_name=AWS_REGION
     )
+    supported_regions = [
+        "af-south-1",
+        "ap-east-1",
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "me-south-1",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
+    ]
+    active_regions = []
+    my_regions = []
+    ssm_regions = []
     try:
         describe_regions_response = client.describe_regions(AllRegions=False)
         regions = describe_regions_response['Regions']
-        active_regions = []
-        my_regions = []
         for region in regions:
             active_regions += [region['RegionName']]
         for region in active_regions:
             if region not in EXCLUDE_REGIONS:
                 my_regions += [region]
-        return my_regions
-    except Exception as e:
-        return e
-
-def get_ssm_regions():
-    try:
-        supported_regions = [
-            "af-south-1",
-            "ap-east-1",
-            "ap-northeast-1",
-            "ap-northeast-2",
-            "ap-south-1",
-            "ap-southeast-1",
-            "ap-southeast-2",
-            "ca-central-1",
-            "eu-central-1",
-            "eu-north-1",
-            "eu-south-1",
-            "eu-west-1",
-            "eu-west-2",
-            "eu-west-3",
-            "me-south-1",
-            "sa-east-1",
-            "us-east-1",
-            "us-east-2",
-            "us-west-1",
-            "us-west-2"
-        ]
-        ssm_regions = []
-        for supported_region in supported_regions:
-            if supported_region not in EXCLUDE_REGIONS:
-                ssm_regions += [supported_region]
-        return ssm_regions
+        for region in my_regions:
+            if region in supported_regions:
+                ssm_regions += [region]
+        return my_regions, ssm_regions
     except Exception as e:
         return e
     
@@ -149,8 +143,7 @@ def lambda_handler(event, context):
     logger.info('Got event {}'.format(event))
     logger.info('Context {}'.format(context))
     aws_account_id = context.invoked_function_arn.split(":")[4]
-    regions = get_active_regions(AWS_REGION)
-    ssm_regions = get_ssm_regions()
+    regions, ssm_regions = get_active_regions(AWS_REGION)
     OrgId = get_management_id()
     try:
         secret_str = get_secret(SECRET_STORE_NAME, SECRET_STORE_REGION)

--- a/templates/aws_cspm_cloudformation_v2.json
+++ b/templates/aws_cspm_cloudformation_v2.json
@@ -536,7 +536,6 @@
         "Handler": "bootstrap",
         "MemorySize": 128,
         "PackageType": "Zip",
-        "ReservedConcurrentExecutions": 100,
         "Role": {
           "Fn::GetAtt": [
             "CrowdStrikeSensorManagementOrchestratorRole",

--- a/templates/crowdstrike_init_stack.yaml
+++ b/templates/crowdstrike_init_stack.yaml
@@ -284,7 +284,7 @@ Resources:
         - DeploymentTargets:
             AccountFilterType: NONE
             OrganizationalUnitIds: !Ref ProvisionOU
-          Regions: !GetAtt TriggerRegisterAccountLambda.my_regions
+          Regions: !GetAtt TriggerRegisterAccountLambda.ssm_regions
       TemplateURL: !Sub https://${SourceS3BucketName}.s3.${S3BucketRegion}.amazonaws.com/${SourceS3BucketNamePrefix}/templates/ssm-association-stackset.yml
 
   SSMSetupStackSet:


### PR DESCRIPTION
add function to lambda to compare supported regions to excluded regions and return list of supported regions in which to deploy SSM Associations for CrowdStrike Distributor package